### PR TITLE
chore: Use node instead of dmtrctl

### DIFF
--- a/bootstrap/stage0/cluster.yml
+++ b/bootstrap/stage0/cluster.yml
@@ -6,10 +6,10 @@ metadata:
   name: hydra-doom-dev-cluster
   # region: us-east-1
   # region: eu-central-1
-  region: us-west-2
+  # region: us-west-2
   # region: ap-southeast-1
   # region: sa-east-1
-  # region: af-south-1
+  region: af-south-1
   tags: 
     sundae-labs:cost-allocation:Service: hydra-doom
 
@@ -70,10 +70,10 @@ managedNodeGroups:
     availabilityZones:
       # - us-east-1b
       # - eu-central-1b
-      - us-west-2b
+      # - us-west-2b
       # - ap-southeast-1a
       # - sa-east-1a
-      # - af-south-1a
+      - af-south-1a
   - name: co-adm-x86-az1
     tags: 
       sundae-labs:cost-allocation:Service: hydra-doom
@@ -90,10 +90,31 @@ managedNodeGroups:
     availabilityZones:
       # - us-east-1b
       # - eu-central-1b
-      - us-west-2b
+      # - us-west-2b
       # - ap-southeast-1a
       # - sa-east-1a
-      # - af-south-1a
+      - af-south-1a
+  - name: co-mem-x86-az1
+    tags: 
+      sundae-labs:cost-allocation:Service: hydra-doom
+    labels:
+      hydra.doom/availability-sla: consistent
+      hydra.doom/compute-profile: mem-intensive
+      hydra.doom/compute-arch: x86
+      hydra.doom/availability-zone: az1
+    instanceType: r6i.2xlarge
+    minSize: 0
+    maxSize: 1
+    desiredCapacity: 1
+    availabilityZones:
+      # - us-east-1b
+      # - eu-central-1b
+      # - us-west-2b
+      # - ap-southeast-1a
+      # - sa-east-1a
+      - af-south-1a
+
+
 
 fargateProfiles:
   - name: fp-default

--- a/bootstrap/stage2/main.tf
+++ b/bootstrap/stage2/main.tf
@@ -281,3 +281,35 @@ variable "proxy_resources" {
     }
   }
 }
+
+variable "node_image" {
+  type    = string
+  default = "ghcr.io/blinklabs-io/cardano-node"
+}
+
+variable "node_image_tag" {
+  type    = string
+  default = "10.1.3"
+}
+
+variable "node_replicas" {
+  type    = number
+  default = 1
+}
+
+variable "node_resources" {
+  type = object({
+    requests = map(string)
+    limits   = map(string)
+  })
+  default = {
+    limits = {
+      "memory" = "22Gi"
+      "cpu"    = "8"
+    }
+    requests = {
+      "memory" = "22Gi"
+      "cpu"    = "2"
+    }
+  }
+}

--- a/bootstrap/stage2/nginx.conf
+++ b/bootstrap/stage2/nginx.conf
@@ -1,0 +1,14 @@
+user root;
+
+events {
+    worker_connections 1024;
+}
+
+stream {
+  server {
+    listen 3307;
+    proxy_pass unix:/ipc/node.socket;
+    proxy_connect_timeout 30s;
+    proxy_timeout 180m;
+  }
+}

--- a/bootstrap/stage2/node.tf
+++ b/bootstrap/stage2/node.tf
@@ -1,0 +1,229 @@
+locals {
+  node_arguments = [
+    "run",
+    "--database-path",
+    "/data/db",
+    "--socket-path",
+    "/ipc/node.socket",
+    "--port",
+    "3000"
+  ]
+  n2n_port_name = "n2n"
+  network       = var.network_id == 0 ? "preprod" : "mainnet"
+  magic         = var.network_id == 0 ? 1 : 764824073
+}
+
+resource "kubernetes_config_map" "node_proxy_config" {
+  metadata {
+    namespace = var.namespace
+    name      = "proxy-${local.network}"
+  }
+
+  data = {
+    "nginx.conf" = "${file("${path.module}/nginx.conf")}"
+  }
+}
+
+resource "kubernetes_config_map" "node_readiness_config" {
+  metadata {
+    namespace = var.namespace
+    name      = "node-readiness"
+  }
+
+  data = {
+    "readiness.sh" = "${file("${path.module}/node_readiness.sh")}"
+  }
+}
+
+resource "kubernetes_stateful_set_v1" "node" {
+  wait_for_rollout = false
+
+  metadata {
+    namespace = var.namespace
+    name      = "node-${local.network}"
+    labels = {
+      network = local.network
+      role    = "cardano-node"
+    }
+  }
+
+  spec {
+    replicas     = var.node_replicas
+    service_name = "nodes-${local.network}"
+
+    selector {
+      match_labels = {
+        network = local.network
+        role    = "cardano-node"
+      }
+    }
+
+    volume_claim_template {
+      metadata {
+        name = "data"
+      }
+      spec {
+        access_modes       = ["ReadWriteOnce"]
+        storage_class_name = "gp2"
+        resources {
+          requests = {
+            storage = "220Gi"
+          }
+        }
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          network = local.network
+          role    = "cardano-node"
+        }
+      }
+
+      spec {
+        volume {
+          name = "ipc"
+          empty_dir {}
+        }
+
+        volume {
+          name = "proxy-config"
+          config_map {
+            name = "proxy-${local.network}"
+          }
+        }
+
+        volume {
+          name = "node-readiness"
+          config_map {
+            name         = "node-readiness"
+            default_mode = "0500"
+          }
+        }
+
+        container {
+          image = "${var.node_image}:${var.node_image_tag}"
+          name  = "main"
+
+          args = local.node_arguments
+
+          env {
+            name  = "CARDANO_NETWORK"
+            value = local.network
+          }
+
+          env {
+            name  = "RESTORE_SNAPSHOT"
+            value = "true"
+          }
+
+          env {
+            name  = "CARDANO_NODE_SOCKET_PATH"
+            value = "/ipc/node.socket"
+          }
+
+          env {
+            name  = "CARDANO_NODE_NETWORK_ID"
+            value = local.magic
+          }
+
+          resources {
+            limits   = var.node_resources.limits
+            requests = var.node_resources.requests
+          }
+
+          port {
+            name           = local.n2n_port_name
+            container_port = 3000
+          }
+
+          port {
+            name           = "metrics"
+            container_port = 12798
+          }
+
+          volume_mount {
+            mount_path = "/data"
+            name       = "data"
+          }
+
+          volume_mount {
+            mount_path = "/ipc"
+            name       = "ipc"
+          }
+
+          volume_mount {
+            mount_path = "/probes"
+            name       = "node-readiness"
+          }
+
+          readiness_probe {
+            initial_delay_seconds = 20
+            exec {
+              command = ["/probes/readiness.sh"]
+            }
+          }
+        }
+
+        container {
+          name  = "nginx"
+          image = "nginx"
+
+          resources {
+            limits = {
+              memory = "100Mi"
+            }
+            requests = {
+              cpu    = "10m"
+              memory = "100Mi"
+            }
+          }
+
+          port {
+            name           = "n2c"
+            container_port = 3307
+          }
+
+          volume_mount {
+            mount_path = "/ipc"
+            name       = "ipc"
+          }
+
+          volume_mount {
+            mount_path = "/etc/nginx"
+            name       = "proxy-config"
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service_v1" "node" {
+  metadata {
+    name      = "node-${local.network}"
+    namespace = var.namespace
+  }
+
+  spec {
+    port {
+      name     = "n2c"
+      protocol = "TCP"
+      port     = 3307
+    }
+
+    port {
+      name     = "n2n"
+      protocol = "TCP"
+      port     = 3000
+    }
+
+    selector = {
+      "role"    = "cardano-node"
+      "network" = local.network
+    }
+
+    type = "ClusterIP"
+  }
+}

--- a/bootstrap/stage2/node_readiness.sh
+++ b/bootstrap/stage2/node_readiness.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq is not installed. Please install jq to use this script."
+    exit 1
+fi
+
+if ! command -v cardano-cli &> /dev/null; then
+    echo "Error: cardano-cli is not installed. Please install cardano-cli to use this script."
+    exit 1
+fi
+
+if ! command -v bc &> /dev/null; then
+    echo "Error: bc is not installed. Please install bc to use this script."
+    exit 1
+fi
+
+if [ "$CARDANO_NODE_NETWORK_ID" == "764824073" ]; then
+    JSON_DATA=$(cardano-cli query tip --mainnet)
+else
+    JSON_DATA=$(cardano-cli query tip --testnet-magic "$CARDANO_NODE_NETWORK_ID")
+fi
+
+SYNC_PROGRESS=$(echo "$JSON_DATA" | jq -r '.syncProgress')
+MIN_EXPECTED_SYNC_PROGRESS="99.00"
+MAX_EXPECTED_SYNC_PROGRESS="100.00"
+
+if (( $(echo "$SYNC_PROGRESS >= $MIN_EXPECTED_SYNC_PROGRESS" | bc -l) )) && (( $(echo "$SYNC_PROGRESS <= $MAX_EXPECTED_SYNC_PROGRESS" | bc -l) )); then
+    echo "syncProgress is within the acceptable range of 99 to 100"
+else
+    echo "Error: syncProgress is not within the acceptable range of 99 to 100"
+    exit 1
+fi


### PR DESCRIPTION
Includes commits of #136 . Should be deployed after the nodes are already created.